### PR TITLE
ext-sockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && \
         libcurl4-openssl-dev libevent-dev libicu-dev libidn11-dev libidn2-0-dev && \
     docker-php-ext-configure gd --enable-gd-native-ttf --with-jpeg-dir=/usr/lib/x86_64-linux-gnu \
         --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu && \
-    docker-php-ext-install bcmath opcache gd pdo_mysql exif intl zip && \
+    docker-php-ext-install bcmath opcache gd pdo_mysql exif intl zip sockets && \
     pecl install -f mongodb-1.3.4 && docker-php-ext-enable mongodb && \
     pecl install apcu  && docker-php-ext-enable apcu  && \
     pecl install raphf && docker-php-ext-enable raphf && \


### PR DESCRIPTION
Ajout de `ext-sockets` qui est requis par `php-amqplib`. J'ai testé le build en local et ça build bien :)
